### PR TITLE
fix: correct syntax error in api.ts ROOT_CATEGORIES endpoint

### DIFF
--- a/renderer/types/api.ts
+++ b/renderer/types/api.ts
@@ -134,7 +134,7 @@ export const API_ENDPOINTS = {
   // Categories
   CATEGORIES: '/api/v1/categories/',
   CATEGORY_BY_ID: (id: string) => `/api/v1/categories/${id}/`,
-  ROOT_CATEGORIES: '/api/v1/categories/roots/`,
+  ROOT_CATEGORIES: '/api/v1/categories/roots/',
   
   // Search
   SEARCH_ARTICLES: '/api/v1/search/articles/',


### PR DESCRIPTION
## Summary
- Fixed string termination character from backtick (`) to single quote (') in renderer/types/api.ts line 137
- Resolves TypeScript compilation error
- Ensures proper string literal syntax for ROOT_CATEGORIES endpoint definition

## Test plan
- [x] TypeScript compilation of api.ts file succeeds
- [x] Docker environment starts successfully
- [x] Related files (useCategories.ts) function correctly

🤖 Generated with [Claude Code](https://claude.ai/code)